### PR TITLE
Fix verbose `sint2dc` and `numpy.complex_` deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+pyseistr.egg-info/
+*.so
+*.pyc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]
+build-backend = "setuptools.build_meta"

--- a/pyseistr/fk.py
+++ b/pyseistr/fk.py
@@ -59,7 +59,7 @@ def fkdip(d,w):
 	Dtmp=np.fft.ifft(np.fft.ifftshift(Dtmp2,1),nk,1);
 
 	#honor symmetry for inverse fft
-	Dfft2=np.zeros([nf,nk],dtype=np.complex_);
+	Dfft2=np.zeros([nf,nk],dtype=np.complex128);
 	Dfft2[0:nf2+1,:]=Dtmp;
 	Dfft2[nf2+1:,:]=np.conj(np.flipud(Dtmp[1:-1,:]));
 	d0=np.real(np.fft.ifft(Dfft2,nf,0));

--- a/pyseistr/src/soint2d_cfuns.c
+++ b/pyseistr/src/soint2d_cfuns.c
@@ -2511,7 +2511,7 @@ static PyObject *csint2d(PyObject *self, PyObject *args){
 	}
 	lam = sqrtf(lam/n12);
 	
-	ps_conjgrad_init(n12, n12, n12, n12, lam, 10*FLT_EPSILON, true, true); 
+	ps_conjgrad_init(n12, n12, n12, n12, lam, 10*FLT_EPSILON, verb, true); 
 
 	if (NULL != qq) {
 // 	    ps_floatread(qq[0],n12,dip);


### PR DESCRIPTION
This PR fixes two problems,
- the verbosity in `sint2dc` was hard coded. This is fixed
- `numpy.complex_` is deprecated and can't be used in the `fk.py`